### PR TITLE
markdown-syntax-propertize no longer needed.

### DIFF
--- a/sx-question-print.el
+++ b/sx-question-print.el
@@ -772,8 +772,6 @@ move point, don't create the code-block button."
   (let ((beg (line-beginning-position)))
     ;; To identify code-blocks we need to be at start of line.
     (goto-char beg)
-    (when (fboundp 'markdown-syntax-propertize)
-      (markdown-syntax-propertize (point) (point-max)))
     (when (markdown-match-pre-blocks (line-end-position))
       (unless dont-fontify
         (sx-babel--make-pre-button beg (point)))


### PR DESCRIPTION
#311,  #312,  #313 don't seem to crop up anymore after removing this.

fbdfff2 added a markdown propertizer that seems to no longer be needed and prevents answers from being shown -  from a cursory glance, looks like markdown-mode.el did a major refactor of their matching block constructs code: https://github.com/defunkt/markdown-mode/commit/e72bd3fb98f45ca3e4d26c9cd72436a18243d1c2

Fixes #315.
